### PR TITLE
Fix competenties configuration issue

### DIFF
--- a/backup_external_courses_helper.class.php
+++ b/backup_external_courses_helper.class.php
@@ -74,7 +74,6 @@ abstract class backup_external_courses_helper {
         'histories'          => '1',
         'questionbank'       => '1',
         'groups'             => '1',
-        'competencies'       => '1',
         'contentbankcontent' => '1',
         'legacyfiles'        => '1',
         'permissions'       => '1'
@@ -124,6 +123,10 @@ abstract class backup_external_courses_helper {
     public static function launch_automated_backup_delete($course, $withuserdatas=0) {
         global $CFG;
         require_once($CFG->dirroot.'/backup/util/includes/backup_includes.php');
+        $iscompetencyenabled = get_config('core_competency', 'enabled');
+        if ($withuserdatas && $iscompetencyenabled) {
+            self::$settingsuserdatas['competencies'] = 1;
+        }
         $customsettings = ($withuserdatas ? self::$settingsuserdatas : self::$settingsnouserdatas);
         $customsettings = (object)$customsettings;
         $bc = new backup_controller(backup::TYPE_1COURSE, $course->id, backup::FORMAT_MOODLE,


### PR DESCRIPTION
In case of core_competenties is disabled. The backup could not be performed due to the following error:

`
Execute scheduled task: tâche du plugin restaurer vos cours depuis des Moodle distants (block_my_external_backup_restore_courses\task\backup_restore_task)
... started 11:55:02. Current memory use 61.9 Mo.
... used 20 dbqueries
... used 3.2084729671478 seconds
Scheduled task failed: tâche du plugin restaurer vos cours depuis des Moodle distants (block_my_external_backup_restore_courses\task\backup_restore_task),Call to undefined method base_setting_exception::get_status()
`

A possible fix could be the following. we check before adding the competenties entry in the array if the parameter is set.